### PR TITLE
Allow removal of channels field by an other FormExtension without throwing exception

### DIFF
--- a/src/DependencyInjection/SyliusPlusCompatibilityTrait.php
+++ b/src/DependencyInjection/SyliusPlusCompatibilityTrait.php
@@ -30,7 +30,7 @@ trait SyliusPlusCompatibilityTrait
         // class to override channel(s) fields of original types.
         foreach ($extendables as $code => $type) {
             $container->setDefinition(
-                'monsieurbiz_cms_page.sylius_plus_adapter.form_extension.filtered_channel_choice_type.' . $code,
+                'monsieurbiz_sylius_plus_adapter.form_extension.filtered_channel_choice_type.' . $code,
                 (new Definition(FilteredChannelChoiceTypeExtension::class))
                     ->setAutowired(true)
                     ->addMethodCall('addExtendedType', [$type])
@@ -73,7 +73,7 @@ trait SyliusPlusCompatibilityTrait
 
         // Add alias because class name in `expr:service` seems to not work
         $container->setAlias(
-            'monsieurbiz_cms_page.sylius_plus_adapter.channel_restricted_query_builder',
+            'monsieurbiz_sylius_plus_adapter.channel_restricted_query_builder',
             ChannelRestrictionQueryBuilderInterface::class
         )->setPublic(true);
 
@@ -84,7 +84,7 @@ trait SyliusPlusCompatibilityTrait
                 'class' => $class,
                 'repository' => [
                     'method' => [
-                        "expr:service('monsieurbiz_cms_page.sylius_plus_adapter.channel_restricted_query_builder')",
+                        "expr:service('monsieurbiz_sylius_plus_adapter.channel_restricted_query_builder')",
                         $hasMultipleChannels ? 'createForChannels' : 'createForChannel',
                     ],
                     'arguments' => [$originalQueryBuilderExpression],

--- a/src/Form/Extension/FilteredChannelChoiceTypeExtension.php
+++ b/src/Form/Extension/FilteredChannelChoiceTypeExtension.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace MonsieurBiz\SyliusPlusAdapterPlugin\Form\Extension;
 
-use DomainException;
 use Sylius\Bundle\ChannelBundle\Form\Type\ChannelChoiceType;
 use Sylius\Component\Channel\Model\ChannelsAwareInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
@@ -62,7 +61,7 @@ final class FilteredChannelChoiceTypeExtension extends AbstractTypeExtension
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if (false === $builder->has(self::CHANNELS) && false === $builder->has(self::CHANNEL)) {
-            throw new DomainException(sprintf('%s should always have channels field defined', self::$extendedTypes[0]));
+            return;
         }
 
         $code = false !== $builder->has(self::CHANNELS) ? self::CHANNELS : self::CHANNEL;


### PR DESCRIPTION
In case another formExtension wants to remove the fields `channels` for any reasons it can without breaking the Form by throwing an exception